### PR TITLE
add legacy node flag ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /node_modules
 
 # IDEs and editors
-/.idea
+.idea
 .project
 .classpath
 .c9/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--openssl-legacy-provider


### PR DESCRIPTION
I always run into this error trying to run npm build or start locally on the candidate exercises until I add this node ssl flag